### PR TITLE
Add support for videos at office.com

### DIFF
--- a/sites.conf
+++ b/sites.conf
@@ -10,7 +10,7 @@ bambuser        iframe  http://embed.bambuser.com/broadcast/@VIDEO@
 metacafe        iframe  http://www.metacafe.com/embed/@VIDEO@/
 bliptv          iframe  //blip.tv/play/@VIDEO@.x?p=1
 break           iframe  //www.break.com/embed/@VIDEO@?embed=1
-msn             iframe  http://hub.video.msn.com/embed/@VIDEO@/
+msoffice        iframe  http://hub.video.msn.com/embed/@VIDEO@/
 
 5min            flash   http://www.5min.com/Embeded/@VIDEO@/
 clipfish        flash   //www.clipfish.de/cfng/flash/clipfish_player_3.swf?as=0&vid=@VIDEO@&r=1&angebot=extern&

--- a/sites.js
+++ b/sites.js
@@ -25,7 +25,7 @@ var sites = {
     'bliptv':      '(?:blip\\.tv\\/play\\/([a-zA-Z0-9]+\\.(?:html|x))\\?p=1|(http?\\:\\/\\/blip\\.tv\\/(?!play)(?:[a-zA-Z0-9_\\-]+)\\/(?:[a-zA-Z0-9_\\-]+)))',
     'break':       'break\\.com\\/video\\/(?:(?:[a-z]+)\\/)?(?:[a-z\\-]+)-([0-9]+)',
     'viddler':     'viddler\\.com\\/(?:embed|v)\\/([a-z0-9]{8})',
-    'msn':         '(?:office\\.com.*[&?]videoid=([a-z0-9\\-]+))',
+    'msoffice':         '(?:office\\.com.*[&?]videoid=([a-z0-9\\-]+))',
     'slideshare':  '(?:(?:slideshare\\.net\\/slideshow\\/embed_code\\/|id=)([0-9]+)|(https?\\:\\/\\/www\\.slideshare\\.net\\/(?:[a-zA-Z0-9_\\-]+)\\/(?:[a-zA-Z0-9_\\-]+)))'
 };
 


### PR DESCRIPTION
The link resolution does not yet work for videos at `hub.video.msn.com` in general, but only for sharelinks to `office.com/...?videoid=...`
