### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -44,7 +44,7 @@ class syntax_plugin_vshare extends DokuWiki_Syntax_Plugin {
     /**
      * Parse the parameters
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         $command = substr($match,2,-2);
 
         // title
@@ -144,7 +144,7 @@ class syntax_plugin_vshare extends DokuWiki_Syntax_Plugin {
     /**
      * Render the flash player
      */
-    function render($mode, &$R, $data){
+    function render($mode, Doku_Renderer $R, $data){
         if($mode != 'xhtml') return false;
         if(is_null($data)) return false;
 


### PR DESCRIPTION
Since PHP 7 method signatures with type hints have to match when
overwriting them. This patch adjusts the plugin signatures to match
what recent DokuWiki versions use.

Please note that this code adjustment and the resulting pull request
were created using an automated tool. If you think the code submitted
is wrong, please feel free to close this PR and excuse the mess.