### PR TITLE
adding aspect ratio param

### DIFF
--- a/sites.ini
+++ b/sites.ini
@@ -6,20 +6,6 @@
 ; rex = a regular expression that can extract the vid from the web or emb url
 ; nfo = a hint on how to find the right URL to paste
 
-[stwst]
-url = //video.stwst.at/videos/embed/@VIDEO@
-vid = n4CcD7kUDcZgjsSbn465
-web = https://video.stwst.at/w/n4CcD7kUDcZgjsSbn465Sk
-rex = video.stwst.at/w/([a-z0-9_\-]+)
-
-[video]
-url = //video.stwst.at/videos/embed/@VIDEO@
-vid = n4CcD7kUDcZgjsSbn465
-web = https://video.stwst.at/w/n4CcD7kUDcZgjsSbn465Sk
-rex = video.stwst.at/w/([a-z0-9_\-]+)
-
-
-
 [youtube]
 url = //www.youtube-nocookie.com/embed/@VIDEO@
 vid = W86cTIoMv2U


### PR DESCRIPTION
We find ourselves having a lot of archive (digitized) videos that are not in 16:9 but still should be responsive and full width.

Not sure if it's the most elegant solution, but I added parser that looks for a parameter like "4:3" or "16:9" and adds the matching aspect-ratio definition to the styles of the iframe  (and unset the height, if there's an aspect ration definition)

I also added a coercion (back) to string to the condition in the sizeToStyle function as this was resulting in "width: 100%px"

let me know if you find this useful or think it needs further improvement.